### PR TITLE
fix: allow github.action_path in bun-actions

### DIFF
--- a/.github/actions/bun-actions/action.yml
+++ b/.github/actions/bun-actions/action.yml
@@ -67,15 +67,14 @@ runs:
             resolved_path="$(realpath -m "$install_path")"
           else
             resolved_path="$(realpath -m "$workspace_root/$install_path")"
+            case "$resolved_path" in
+              "$workspace_root"|"$workspace_root"/*) ;;
+              *)
+                echo "Install path escapes workspace: $install_path" >&2
+                exit 1
+                ;;
+            esac
           fi
-
-          case "$resolved_path" in
-            "$workspace_root"|"$workspace_root"/*) ;;
-            *)
-              echo "Install path escapes workspace: $install_path" >&2
-              exit 1
-              ;;
-          esac
 
           (
             cd "$resolved_path"


### PR DESCRIPTION
## Summary
- allow absolute `working-directory` values when they come from the fallback path
- keep the workspace boundary check for workspace-relative installs and explicit `install-paths`
- restore compatibility for nested composite actions that pass `${{ github.action_path }}`

## Root cause
The recent `install-paths` hardening added a workspace boundary check after both resolution branches. When a caller passes an absolute `working-directory` such as `${{ github.action_path }}`, the path resolves correctly but is then rejected because action source lives under `_actions`, outside `GITHUB_WORKSPACE`.

## Evidence
- failing run: https://github.com/iamvikshan/amina/actions/runs/23248717698/job/67584344939
- shared action consumed by: `iamvikshan/gitsync@v1.0.1`

## Risk
This intentionally permits absolute paths only for the `working-directory` fallback path. Explicit `install-paths` remains workspace-restricted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `bun-actions` working-directory resolution to allow absolute paths from `github.action_path`, restoring support for nested composite actions. Workspace boundary checks still apply to workspace-relative installs and explicit `install-paths`.

- **Bug Fixes**
  - Run boundary check only for workspace-relative paths; allow absolute fallback paths (e.g., from `github.action_path`).
  - Continue rejecting `install-paths` that escape `GITHUB_WORKSPACE`.

<sup>Written for commit 7625e35c93124c7f952fe4ef0d94c3bacb8d50bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal workspace validation logic in the build process for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->