### PR TITLE
fix: harden bootstrap signing and GitLab force push

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -150,7 +150,7 @@ if [ ! -f "${KEY_PATH}.pub" ]; then
   echo -e "${RED}Cannot set local signing key. Exiting.${NC}" >&2
   exit 1
 fi
-git config --local user.signingkey "${KEY_PATH}.pub" 2>/dev/null || true
+git config --local user.signingkey "${KEY_PATH}.pub"
 
 # --- Helper Functions for API Keys ---
 ensure_jq() {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -145,6 +145,11 @@ git config --global user.signingkey "${KEY_PATH}.pub"
 git config --global commit.gpgsign true
 
 # Pin the repo to the generated signing key so stale host configs cannot win
+if [ ! -f "${KEY_PATH}.pub" ]; then
+  echo -e "${RED}ERROR: Public key file ${KEY_PATH}.pub does not exist.${NC}" >&2
+  echo -e "${RED}Cannot set local signing key. Exiting.${NC}" >&2
+  exit 1
+fi
 git config --local user.signingkey "${KEY_PATH}.pub" 2>/dev/null || true
 
 # --- Helper Functions for API Keys ---

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -144,6 +144,9 @@ git config --global gpg.format ssh
 git config --global user.signingkey "${KEY_PATH}.pub"
 git config --global commit.gpgsign true
 
+# Pin the repo to the generated signing key so stale host configs cannot win
+git config --local user.signingkey "${KEY_PATH}.pub" 2>/dev/null || true
+
 # --- Helper Functions for API Keys ---
 ensure_jq() {
   if ! command -v jq &> /dev/null; then
@@ -227,6 +230,36 @@ prune_gitlab_keys() {
   fi
 }
 
+enable_gitlab_force_push() {
+  if [[ -z "$GL_TOKEN" ]]; then return 0; fi
+
+  echo -e "Attempting to enable force pushes on GitLab main branch..."
+  ensure_jq || return 0
+
+  local project_id
+  project_id=$(curl -s --header "PRIVATE-TOKEN: $GL_TOKEN" \
+    "https://gitlab.com/api/v4/projects/${GL_NAMESPACE}%2F${REPO_NAME}" 2>/dev/null | jq -r '.id // empty' 2>/dev/null)
+
+  if [[ -z "$project_id" ]]; then
+    echo -e "${YELLOW}⚠️ Could not fetch GitLab project ID. Force push configuration skipped.${NC}"
+    echo -e "${YELLOW}   (This is expected for newly created projects; manually enable via GitLab UI if needed).${NC}"
+    return 1
+  fi
+
+  local http_status
+  http_status=$(curl -s -o /dev/null -w "%{http_code}" -X PATCH \
+    --header "PRIVATE-TOKEN: $GL_TOKEN" \
+    "https://gitlab.com/api/v4/projects/${project_id}/protected_branches/main?allow_force_push=true")
+
+  if [[ "$http_status" == "200" ]]; then
+    echo -e "✓ Force push enabled on GitLab main branch."
+  elif [[ "$http_status" == "404" ]]; then
+    echo -e "${YELLOW}⚠️ Protected branch 'main' not found on GitLab. This is expected for new projects.${NC}"
+  else
+    echo -e "${YELLOW}⚠️ Could not enable force push (HTTP $http_status). You may need to do this manually.${NC}"
+  fi
+}
+
 # 7. Upload SSH Key to APIs & Prune
 PUB_KEY=$(cat "${KEY_PATH}.pub")
 
@@ -298,6 +331,10 @@ if [[ "$GL_NAMESPACE" != "SKIP" ]]; then
   
   git remote set-url --add --push origin "$GL_REMOTE"
   echo -e "✓ GitLab push remote configured (${GL_NAMESPACE}/${REPO_NAME})."
+
+  if [[ -n "$GL_TOKEN" ]]; then
+    enable_gitlab_force_push
+  fi
 fi
 
 # 9. Fetch and Apply Git Hooks


### PR DESCRIPTION
This updates `scripts/bootstrap.sh` to make bootstrap runs more reliable across hosts and GitLab setups.

What changed:
- Pin the repository to the generated SSH signing key so stale local config cannot override it
- Validate the SSH signing key exists before continuing
- Add GitLab protected-branch force-push enablement through the REST API when a PAT is available
- Keep the existing token, remote, and hook workflow intact

This addresses the commit-signing failure caused by a missing local key path and makes the GitLab setup more explicit for protected branches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the bootstrap script to make SSH commit signing reliable and optionally enable force pushes on GitLab protected branches. This prevents signing failures from missing or overridden keys and smooths GitLab setup when a token is available.

- **Bug Fixes**
  - Pin repo-local `user.signingkey` to the generated SSH key to avoid stale global/host config.
  - Fail fast if the public key `${KEY_PATH}.pub` is missing before setting the local signing key.

- **New Features**
  - Enable force push on GitLab `main` via the protected-branches API when `GL_TOKEN` is set, skipping if `jq` or the project ID is unavailable, handling missing protected branches on new projects, and printing clear guidance.

<sup>Written for commit a916da2c828a7d4ecdb65596089456fb98a77ff9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository-specific SSH signing key is validated and applied locally, ensuring commits are signed per-repo.
  * Optional enabling of force-push on the protected main branch for GitLab projects when an access token is provided.

* **Improvements**
  * Improved bootstrap flow with clearer logging for remote and API actions and safer failure behavior when project info is missing.
  * Minor output formatting adjustment (final blank line).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iamvikshan/.github/pull/25)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->