### PR TITLE
Implement cross-platform realpath function

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -31,9 +31,20 @@ runs:
           if [[ -e "$path" ]]; then
             realpath "$path"
           else
-            # For non-existent paths, resolve parent directory and append basename
-            local parent="$(cd "$(dirname "$path")" && pwd -P)"
-            echo "$parent/$(basename "$path")"
+            # Walk up until we find an existing ancestor, accumulating missing suffix
+            local suffix=""
+            local current="$path"
+            while [[ ! -e "$current" && "$current" != "/" && "$current" != "." ]]; do
+              suffix="/$(basename "$current")$suffix"
+              current="$(dirname "$current")"
+            done
+            local resolved
+            if [[ -e "$current" ]]; then
+              resolved="$(realpath "$current")"
+            else
+              resolved="$(pwd -P)"
+            fi
+            echo "${resolved}${suffix}"
           fi
         }
 

--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -25,7 +25,19 @@ runs:
       run: |
         set -euo pipefail
 
-        workspace_root="$(realpath -m "$GITHUB_WORKSPACE")"
+        # Cross-platform realpath replacement that handles non-existent paths
+        realpath_m() {
+          local path="$1"
+          if [[ -e "$path" ]]; then
+            realpath "$path"
+          else
+            # For non-existent paths, resolve parent directory and append basename
+            local parent="$(cd "$(dirname "$path")" && pwd -P)"
+            echo "$parent/$(basename "$path")"
+          fi
+        }
+
+        workspace_root="$(realpath_m "$GITHUB_WORKSPACE")"
         install_paths=()
         install_args=()
 
@@ -65,7 +77,7 @@ runs:
           bun install "${install_args[@]}"
         else
           for install_path in "${install_paths[@]}"; do
-            resolved_path="$(realpath -m "$workspace_root/$install_path")"
+            resolved_path="$(realpath_m "$workspace_root/$install_path")"
 
             case "$resolved_path" in
               "$workspace_root"|"$workspace_root"/*) ;;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `realpath -m` with a portable `realpath_m` in `.github/actions/setup-bun` that resolves existing and missing paths on Linux and macOS. It safeguards `workspace_root` and install path checks by walking up to the nearest existing directory and appending the missing suffix to avoid resolution failures.

<sup>Written for commit f85efe677c6406a0134984bf22eb076defa2862a. Summary will update on new commits. <a href="https://cubic.dev/pr/iamvikshan/.github/pull/26?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the setup action's path resolution: introduced a more robust resolver and switched path handling to better support cross-platform scenarios and cases where target paths do not yet exist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iamvikshan/.github/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->