### PR TITLE
feat(actions): add customizable node-version input to setup-node-bun

### DIFF
--- a/.github/actions/setup-node-bun/action.yml
+++ b/.github/actions/setup-node-bun/action.yml
@@ -1,6 +1,10 @@
 name: "Setup node-bun Environment"
 description: "Setup Node.js, Bun, and install dependencies"
 inputs:
+  node-version:
+    description: "Node.js version to set up"
+    required: false
+    default: "latest"
   install-paths:
     description: "Newline-separated paths to install dependencies in, relative to the workspace root"
     required: false
@@ -15,7 +19,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v6.4.0
       with:
-        node-version: "latest"
+        node-version: ${{ inputs.node-version }}
 
     - name: Setup Bun and install dependencies
       uses: iamvikshan/.github/.github/actions/setup-bun@main


### PR DESCRIPTION
This PR introduces a customizable 'node-version' input parameter to the setup-node-bun action, enabling calling workflows to specify their preferred Node.js version. It defaults to 'latest' to preserve backward compatibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `node-version` input to the `setup-node-bun` action so workflows can choose the Node.js version. Defaults to `latest` to preserve existing behavior.

<sup>Written for commit 27b39fb2d66db2f9319811bac67ae5c5e0d721ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/iamvikshan/.github/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build pipeline configuration flexibility for Node version setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->