### PR TITLE
Update Git configuration commands in bootstrap script

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -86,7 +86,7 @@ GL_NAMESPACE="${GL_NAMESPACE:-$DEFAULT_GL_NAMESPACE}"
 GL_REPO="${GL_REPO:-$GH_REPO}"
 
 # Tell Git to trust the current workspace before running any git commands
-if ! git config --global --get-all safe.directory | grep -qF "$PWD"; then
+if ! git config --global --get-all safe.directory | grep -qxF "$PWD"; then
   git config --global --add safe.directory "$PWD"
 fi
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -85,6 +85,11 @@ GH_REPO="${GH_REPO:-$(basename "$PWD")}"
 GL_NAMESPACE="${GL_NAMESPACE:-$DEFAULT_GL_NAMESPACE}"
 GL_REPO="${GL_REPO:-$GH_REPO}"
 
+# Tell Git to trust the current workspace before running any git commands
+if ! git config --global --get-all safe.directory | grep -qF "$PWD"; then
+  git config --global --add safe.directory "$PWD"
+fi
+
 REMOTE_URL=$(git config --get remote.origin.url || true)
 if [[ -n "$REMOTE_URL" ]]; then
   if [[ "$REMOTE_URL" =~ github\.com[:/]([^/]+)/([^.]+)(\.git)?$ ]]; then
@@ -154,9 +159,6 @@ EOF
 fi
 
 echo -e "\nConfiguring Git identity for ${GIT_AUTHOR_NAME}..."
-# Tell Git to trust the current workspace, regardless of directory ownership
-git config --global --add safe.directory "$PWD"
-
 git config --global user.name "$GIT_AUTHOR_NAME"
 git config --global user.email "$GIT_AUTHOR_EMAIL"
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -154,6 +154,9 @@ EOF
 fi
 
 echo -e "\nConfiguring Git identity for ${GIT_AUTHOR_NAME}..."
+# Tell Git to trust the current workspace, regardless of directory ownership
+git config --global --add safe.directory "$PWD"
+
 git config --global user.name "$GIT_AUTHOR_NAME"
 git config --global user.email "$GIT_AUTHOR_EMAIL"
 
@@ -179,7 +182,11 @@ if [ ! -f "${KEY_PATH}.pub" ]; then
   echo -e "${RED}ERROR: Public key file ${KEY_PATH}.pub does not exist.${NC}" >&2
   exit 1
 fi
-git config --local user.signingkey "${KEY_PATH}.pub"
+
+# Safely overwrite Codespaces local GPG injection if inside a git tree
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git config --local user.signingkey "${KEY_PATH}.pub"
+fi
 
 # --- Helper Functions for API Keys ---
 ensure_jq() {
@@ -348,8 +355,10 @@ fi
 
 # 9. Local Identity Guard Setup
 echo -e "\n--- Local Identity Guard ---"
-git config --local atlas.expected-name "$GIT_AUTHOR_NAME"
-git config --local atlas.expected-email "$GIT_AUTHOR_EMAIL"
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git config --local atlas.expected-name "$GIT_AUTHOR_NAME"
+  git config --local atlas.expected-email "$GIT_AUTHOR_EMAIL"
+fi
 
 mkdir -p .husky/_
 curl -sL https://raw.githubusercontent.com/iamvikshan/.github/main/scripts/husky/identity-guard.sh > .husky/_/identity-guard.sh 2>/dev/null || true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `git` config in the bootstrap script safer by trusting the current workspace and only writing local settings inside a repo. Prevents ownership warnings and keeps Codespaces GPG injection intact outside repos.

- **Bug Fixes**
  - Add global `git` `safe.directory` for the current path.
  - Only set local `user.signingkey` when `git rev-parse --is-inside-work-tree` succeeds.
  - Only set local `atlas.expected-name` and `atlas.expected-email` under the same check.

<sup>Written for commit 75db76ddd6dc66b266fdb1864f4c55f34dbf6962. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/iamvikshan/.github/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Initialization script now preemptively marks the workspace as trusted for Git operations and adds safeguards to avoid writing local Git identity or signing settings unless the directory is a Git working tree, reducing unintended local config changes during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->