### PR TITLE
chore: add bash fallback to enforce zsh as default shell

### DIFF
--- a/scripts/omz.sh
+++ b/scripts/omz.sh
@@ -118,6 +118,23 @@ EOF
 
 echo -e "${GREEN}✓ .zshrc configured successfully.${NC}"
 
+echo -e "${YELLOW}▶ Adding Zsh fallback to .bashrc...${NC}"
+# If bash is ever launched interactively, instantly switch to Zsh
+BASH_FALLBACK_SNIPPET='
+# Automatically switch to Zsh
+if [[ $- == *i* ]] && [ -x "$(command -v zsh)" ]; then
+    export SHELL="$(command -v zsh)"
+    exec zsh -l
+fi
+'
+
+if ! grep -q 'exec zsh' "$HOME/.bashrc" 2>/dev/null; then
+    echo "$BASH_FALLBACK_SNIPPET" >> "$HOME/.bashrc"
+    echo -e "${GREEN}✓ Fallback added to .bashrc.${NC}"
+else
+    echo -e "${BLUE}ℹ Zsh fallback already present in .bashrc.${NC}"
+fi
+
 # 5. Change Default Shell
 echo -e "${YELLOW}▶ Changing default shell to Zsh...${NC}"
 ZSH_PATH=$(command -v zsh)

--- a/scripts/omz.sh
+++ b/scripts/omz.sh
@@ -124,11 +124,15 @@ BASH_FALLBACK_SNIPPET='
 # Automatically switch to Zsh
 if [[ $- == *i* ]] && [ -x "$(command -v zsh)" ]; then
     export SHELL="$(command -v zsh)"
-    exec zsh -l
+    if shopt -q login_shell; then
+        exec zsh -l
+    else
+        exec zsh
+    fi
 fi
 '
 
-if ! grep -q 'exec zsh' "$HOME/.bashrc" 2>/dev/null; then
+if ! grep -Eq '^[[:space:]]*exec[[:space:]]+zsh' "$HOME/.bashrc" 2>/dev/null; then
     echo "$BASH_FALLBACK_SNIPPET" >> "$HOME/.bashrc"
     echo -e "${GREEN}✓ Fallback added to .bashrc.${NC}"
 else


### PR DESCRIPTION
Adds a bash fallback to ~/.bashrc to forcefully start zsh if bash is run interactively.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `scripts/omz.sh` to append a `~/.bashrc` fallback that switches interactive Bash sessions to `zsh` (uses `zsh -l` for login shells), only if the snippet is missing and `zsh` is present.

<sup>Written for commit f69874f82172808f08e18228b9bf44fd0df525e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/iamvikshan/.github/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bash-to-zsh fallback in `~/.bashrc` to enforce zsh as default shell
> Appends a snippet to `~/.bashrc` that execs into a login zsh session when bash is started interactively and zsh is available. The snippet is only added if `exec zsh` is not already present in `~/.bashrc`. Risk: future interactive bash sessions will immediately switch to zsh, which may surprise users who intentionally use bash.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ed960f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive Bash sessions will automatically switch to Zsh when Zsh is available, providing a consistent shell experience without manual switching.
  * The change adds safeguards to avoid duplicate fallback entries and will not modify plugins, generate a .zshrc, change your default shell, or perform any additional setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->