### PR TITLE
feat: adds new universal scripts for docker and bare metal omz setup.

### DIFF
--- a/scripts/omz.sh
+++ b/scripts/omz.sh
@@ -59,12 +59,41 @@ echo -e "${GREEN}✓ Plugins installed.${NC}"
 # 4. Fetch Universal .zshrc Configuration
 echo -e "${YELLOW}▶ Fetching universal .zshrc...${NC}"
 
+# Expected SHA256 checksum of the universal.zshrc file
+EXPECTED_SHA256="PUT_ACTUAL_SHA256_HERE"
+
+# Download to a temporary file first
+TEMP_ZSHRC="$HOME/.zshrc.tmp"
+if ! curl -fsSL https://raw.githubusercontent.com/iamvikshan/.github/refs/heads/main/scripts/universal.zshrc -o "$TEMP_ZSHRC"; then
+    echo "❌ Failed to download universal.zshrc. Keeping existing configuration."
+    rm -f "$TEMP_ZSHRC"
+    exit 1
+fi
+
+# Verify the download succeeded and file exists
+if [ ! -f "$TEMP_ZSHRC" ]; then
+    echo "❌ Download failed - temporary file not found. Keeping existing configuration."
+    exit 1
+fi
+
+# Verify SHA256 checksum
+ACTUAL_SHA256=$(sha256sum "$TEMP_ZSHRC" | awk '{print $1}')
+if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+    echo "❌ Checksum verification failed!"
+    echo "   Expected: $EXPECTED_SHA256"
+    echo "   Got:      $ACTUAL_SHA256"
+    echo "   Keeping existing configuration for safety."
+    rm -f "$TEMP_ZSHRC"
+    exit 1
+fi
+
+# Backup existing .zshrc only after successful download and verification
 if [ -f "$HOME/.zshrc" ]; then
     mv "$HOME/.zshrc" "$HOME/.zshrc.backup-$(date +%s)"
 fi
 
-# Download the universal config directly from your dotfiles repo
-curl -fsSL https://raw.githubusercontent.com/iamvikshan/.github/refs/heads/main/scripts/universal.zshrc -o "$HOME/.zshrc"
+# Atomically move temp file to final location
+mv "$TEMP_ZSHRC" "$HOME/.zshrc"
 
 echo -e "${GREEN}✓ .zshrc configured successfully.${NC}"
 

--- a/scripts/omz.sh
+++ b/scripts/omz.sh
@@ -59,8 +59,6 @@ echo -e "${GREEN}✓ Plugins installed.${NC}"
 # 4. Fetch Universal .zshrc Configuration
 echo -e "${YELLOW}▶ Fetching universal .zshrc...${NC}"
 
-# Expected SHA256 checksum of the universal.zshrc file
-EXPECTED_SHA256="PUT_ACTUAL_SHA256_HERE"
 
 # Download to a temporary file first
 TEMP_ZSHRC="$HOME/.zshrc.tmp"
@@ -73,17 +71,6 @@ fi
 # Verify the download succeeded and file exists
 if [ ! -f "$TEMP_ZSHRC" ]; then
     echo "❌ Download failed - temporary file not found. Keeping existing configuration."
-    exit 1
-fi
-
-# Verify SHA256 checksum
-ACTUAL_SHA256=$(sha256sum "$TEMP_ZSHRC" | awk '{print $1}')
-if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
-    echo "❌ Checksum verification failed!"
-    echo "   Expected: $EXPECTED_SHA256"
-    echo "   Got:      $ACTUAL_SHA256"
-    echo "   Keeping existing configuration for safety."
-    rm -f "$TEMP_ZSHRC"
     exit 1
 fi
 

--- a/scripts/omz.sh
+++ b/scripts/omz.sh
@@ -2,7 +2,7 @@
 
 # ==============================================================================
 # Universal Zsh & Oh My Zsh Installer
-# Tailored with custom git prompt, syntax highlighting, and autosuggestions
+# Fetches configuration from the centralized universal.zshrc
 # ==============================================================================
 
 set -e
@@ -37,7 +37,6 @@ echo -e "${GREEN}✓ Prerequisites installed.${NC}"
 # 2. Install Oh My Zsh (Unattended)
 echo -e "${YELLOW}▶ Installing Oh My Zsh...${NC}"
 if [ ! -d "$HOME/.oh-my-zsh" ]; then
-    # Run the OMZ install script in unattended mode so it doesn't block the script
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
     echo -e "${GREEN}✓ Oh My Zsh installed.${NC}"
 else
@@ -48,78 +47,29 @@ fi
 echo -e "${YELLOW}▶ Installing Zsh plugins...${NC}"
 ZSH_CUSTOM="$HOME/.oh-my-zsh/custom"
 
-# zsh-autosuggestions
 if [ ! -d "$ZSH_CUSTOM/plugins/zsh-autosuggestions" ]; then
     git clone https://github.com/zsh-users/zsh-autosuggestions "$ZSH_CUSTOM/plugins/zsh-autosuggestions" -q
 fi
 
-# zsh-syntax-highlighting
 if [ ! -d "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" ]; then
     git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" -q
 fi
 echo -e "${GREEN}✓ Plugins installed.${NC}"
 
-# 4. Generate the custom .zshrc
-echo -e "${YELLOW}▶ Configuring .zshrc...${NC}"
+# 4. Fetch Universal .zshrc Configuration
+echo -e "${YELLOW}▶ Fetching universal .zshrc...${NC}"
 
-# Backup existing .zshrc if it wasn't created by us just now
 if [ -f "$HOME/.zshrc" ]; then
     mv "$HOME/.zshrc" "$HOME/.zshrc.backup-$(date +%s)"
 fi
 
-# Write your stripped-down, universal config
-cat << 'EOF' > "$HOME/.zshrc"
-# ==============================================================================
-# Custom Zsh Configuration
-# ==============================================================================
-
-# Ensure local bin is in PATH
-if [[ "${PATH}" != *"$HOME/.local/bin"* ]]; then
-  export PATH="$HOME/.local/bin:${PATH}"
-fi
-
-# Path to your oh-my-zsh installation.
-export ZSH="$HOME/.oh-my-zsh"
-
-# Set theme to empty string since we are building a custom prompt below
-ZSH_THEME=""
-
-# Plugins list
-plugins=(git bun zsh-autosuggestions zsh-syntax-highlighting)
-
-# Load Oh My Zsh
-source $ZSH/oh-my-zsh.sh
-
-# Allow variable substitution in prompt
-setopt PROMPT_SUBST
-
-# Custom Git Info Function
-__git_info() {
-    local branch
-    branch=$(git --no-optional-locks symbolic-ref --short HEAD 2>/dev/null || git --no-optional-locks rev-parse --short HEAD 2>/dev/null)
-    if [[ -n "${branch}" ]]; then
-        local dirty_flag=""
-        if git --no-optional-locks ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then
-            dirty_flag=" %F{yellow}✗"
-        fi
-        echo "%F{cyan}(%F{red}${branch}${dirty_flag}%F{cyan}) "
-    fi
-}
-
-# The Prompt String (Username replaced GITHUB_USER)
-PROMPT='%(?.%F{green}.%F{red})➜%f %F{green}%n%f %F{blue}%4~%f $(__git_info)%f$ '
-
-# Terminal Title Updates
-if [[ "$TERM" == "xterm" || "$TERM" == "xterm-256color" || "$TERM_PROGRAM" == "vscode" ]]; then
-    preexec() { print -Pn "\e]0;%n@%m: $1\a" }
-    precmd() { print -Pn "\e]0;%n@%m: zsh\a" }
-fi
-EOF
+# Download the universal config directly from your dotfiles repo
+curl -fsSL https://raw.githubusercontent.com/iamvikshan/.github/refs/heads/main/scripts/universal.zshrc -o "$HOME/.zshrc"
 
 echo -e "${GREEN}✓ .zshrc configured successfully.${NC}"
 
+# 5. Add Zsh fallback to .bashrc
 echo -e "${YELLOW}▶ Adding Zsh fallback to .bashrc...${NC}"
-# If bash is ever launched interactively, instantly switch to Zsh
 BASH_FALLBACK_SNIPPET='
 # Automatically switch to Zsh
 if [[ $- == *i* ]] && [ -x "$(command -v zsh)" ]; then
@@ -139,11 +89,10 @@ else
     echo -e "${BLUE}ℹ Zsh fallback already present in .bashrc.${NC}"
 fi
 
-# 5. Change Default Shell
+# 6. Change Default Shell
 echo -e "${YELLOW}▶ Changing default shell to Zsh...${NC}"
 ZSH_PATH=$(command -v zsh)
 if [ "$SHELL" != "$ZSH_PATH" ]; then
-    # We use sudo chsh to ensure it works without prompting for the user's password if they have sudo NOPASSWD
     sudo chsh -s "$ZSH_PATH" "$USER" || chsh -s "$ZSH_PATH"
     echo -e "${GREEN}✓ Default shell changed.${NC}"
 else
@@ -152,5 +101,5 @@ fi
 
 echo -e "\n${GREEN}🎉 Zsh setup complete! Starting your new shell now...${NC}\n"
 
-# 6. Hand over the session instantly to Zsh
+# 7. Hand over the session instantly to Zsh
 exec zsh

--- a/scripts/universal.zshrc
+++ b/scripts/universal.zshrc
@@ -3,7 +3,7 @@
 # ==============================================================================
 
 # Ensure local bin is in PATH
-if [[ "${PATH}" != *"$HOME/.local/bin"* ]]; then
+if [[ ":${PATH}:" != *":$HOME/.local/bin:"* ]]; then
   export PATH="$HOME/.local/bin:${PATH}"
 fi
 
@@ -39,7 +39,7 @@ ZSH_THEME=""
 plugins=(git bun zsh-autosuggestions zsh-syntax-highlighting)
 
 # Load Oh My Zsh
-source $ZSH/oh-my-zsh.sh
+source "$ZSH"/oh-my-zsh.sh
 
 # Allow variable substitution in prompt
 setopt PROMPT_SUBST
@@ -55,7 +55,8 @@ __git_info() {
     if [[ -n "${branch}" ]]; then
         local dirty_flag=""
         # Show dirty flag locally, or if DevContainer config explicitly allows it
-        if [[ "$(git config --get devcontainers-theme.show-dirty 2>/dev/null)" == "1" ]] || [[ -z "${TERM_PROGRAM}" ]]; then
+        # Skip dirty check if SKIP_GIT_DIRTY_CHECK is set
+        if [[ -z "${SKIP_GIT_DIRTY_CHECK}" ]] && { [[ "$(git config --get devcontainers-theme.show-dirty 2>/dev/null)" == "1" ]] || [[ -z "${TERM_PROGRAM}" ]]; }; then
             if git --no-optional-locks ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then
                 dirty_flag=" %F{yellow}✗"
             fi

--- a/scripts/universal.zshrc
+++ b/scripts/universal.zshrc
@@ -1,0 +1,74 @@
+# ==============================================================================
+# Universal Zsh Configuration
+# ==============================================================================
+
+# Ensure local bin is in PATH
+if [[ "${PATH}" != *"$HOME/.local/bin"* ]]; then
+  export PATH="$HOME/.local/bin:${PATH}"
+fi
+
+# DevContainer/Codespaces: Suppress first-run notice
+if [[ -t 1 && ("${TERM_PROGRAM}" == 'vscode' || "${TERM_PROGRAM}" == 'codespaces') && ! -f "$HOME/.config/vscode-dev-containers/first-run-notice-already-displayed" ]]; then
+  if [[ -f '/usr/local/etc/vscode-dev-containers/first-run-notice.txt' ]]; then
+    cat '/usr/local/etc/vscode-dev-containers/first-run-notice.txt'
+  elif [[ -f '/workspaces/.codespaces/shared/first-run-notice.txt' ]]; then
+    cat '/workspaces/.codespaces/shared/first-run-notice.txt'
+  fi
+  mkdir -p "$HOME/.config/vscode-dev-containers"
+  (sleep 10s; touch "$HOME/.config/vscode-dev-containers/first-run-notice-already-displayed") &!
+fi
+
+# Set VS Code as default git editor if applicable
+if [[ -z "$(git config --get core.editor)" && -z "${GIT_EDITOR}" ]]; then
+  if [[ "${TERM_PROGRAM}" == 'vscode' ]]; then
+    if [[ -n "$(command -v code-insiders)" && -z "$(command -v code)" ]]; then
+      export GIT_EDITOR='code-insiders --wait'
+    else
+      export GIT_EDITOR='code --wait'
+    fi
+  fi
+fi
+
+# Path to your oh-my-zsh installation.
+export ZSH="$HOME/.oh-my-zsh"
+
+# Set theme to empty string since we are building a custom prompt below
+ZSH_THEME=""
+
+# Plugins list
+plugins=(git bun zsh-autosuggestions zsh-syntax-highlighting)
+
+# Load Oh My Zsh
+source $ZSH/oh-my-zsh.sh
+
+# Allow variable substitution in prompt
+setopt PROMPT_SUBST
+
+# Custom Git Info Function
+__git_info() {
+    # Respect DevContainer hide-status configs
+    if [[ "$(git config --get devcontainers-theme.hide-status 2>/dev/null)" == "1" ]] || [[ "$(git config --get codespaces-theme.hide-status 2>/dev/null)" == "1" ]]; then
+        return
+    fi
+    local branch
+    branch=$(git --no-optional-locks symbolic-ref --short HEAD 2>/dev/null || git --no-optional-locks rev-parse --short HEAD 2>/dev/null)
+    if [[ -n "${branch}" ]]; then
+        local dirty_flag=""
+        # Show dirty flag locally, or if DevContainer config explicitly allows it
+        if [[ "$(git config --get devcontainers-theme.show-dirty 2>/dev/null)" == "1" ]] || [[ -z "${TERM_PROGRAM}" ]]; then
+            if git --no-optional-locks ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then
+                dirty_flag=" %F{yellow}✗"
+            fi
+        fi
+        echo "%F{cyan}(%F{red}${branch}${dirty_flag}%F{cyan}) "
+    fi
+}
+
+# The Prompt String (Prefers GITHUB_USER if in a container, falls back to %n standard user)
+PROMPT='%(?.%F{green}.%F{red})➜%f %F{green}${GITHUB_USER:-%n}%f %F{blue}%4~%f $(__git_info)%f$ '
+
+# Terminal Title Updates
+if [[ "$TERM" == "xterm" || "$TERM" == "xterm-256color" || "$TERM_PROGRAM" == "vscode" ]]; then
+    preexec() { print -Pn "\e]0;%n@%m: $1\a" }
+    precmd() { print -Pn "\e]0;%n@%m: zsh\a" }
+fi


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes Zsh setup across Docker, Codespaces, and bare metal by fetching a centralized universal `.zshrc`. Simplifies the OMZ installer and adds a portable, container-aware prompt and git status.

- **New Features**
  - Added `scripts/universal.zshrc` with portable prompt, container-aware git status (respects DevContainer/Codespaces hide-status and `SKIP_GIT_DIRTY_CHECK`), VS Code git editor, and DevContainer first-run notice suppression.
  - `scripts/omz.sh` now downloads the universal `.zshrc` to a temp file, backs up existing config only after a successful download, moves atomically, installs `zsh-autosuggestions` and `zsh-syntax-highlighting`, adds Bash→Zsh fallback, switches the default shell, and starts Zsh.

- **Migration**
  - Running `omz.sh` backs up existing `~/.zshrc` and replaces it with the universal config. No other steps required.

<sup>Written for commit 333c8ea74798c0c2a4eec9623abfccb59c4d9e07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/iamvikshan/.github/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add universal Oh My Zsh setup scripts for Docker and bare metal environments
> - [omz.sh](https://github.com/iamvikshan/.github/pull/34/files#diff-32b015af9bcb600137e9abfae2072d7d20c93e590c481b1f80c2da4bb941f7b3) now downloads `~/.zshrc` from a remote URL into a temp file instead of using an inline heredoc; it validates the download, backs up any existing `~/.zshrc` only after a successful fetch, then atomically moves the temp file into place.
> - [universal.zshrc](https://github.com/iamvikshan/.github/pull/34/files#diff-99d3641a1cddee307336b39a74b820fc408cb2bcf258c15172436865f9a8f035) is the new centralized Zsh config: configures Oh My Zsh with `git`, `bun`, `zsh-autosuggestions`, and `zsh-syntax-highlighting` plugins, sets VS Code as the Git editor when appropriate, adds `$HOME/.local/bin` to PATH, and defines a git-status-aware prompt.
> - Risk: `omz.sh` now depends on remote URL availability at install time; a network failure aborts setup and leaves the existing config untouched.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 333c8ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Centralized Zsh configuration with automatic PATH and Git editor setup.
  * Enhanced shell prompt displaying git branch and status information.
  * Terminal window/tab title updates during command execution.
  * Automatic suppression of VS Code DevContainer first-run notices.

* **Improvements**
  * Simplified setup process with optimized plugin installation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->