### PR TITLE
feat: configure secret inputs for reusable workflows

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -166,7 +166,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' || github.event.issue.pull_request }}
     uses: iamvikshan/.github/.github/workflows/pr-agent.yml@main
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
     secrets:

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -145,11 +145,12 @@ Runs PR-Agent reviews, suggestions, and chat interfaces on Pull Requests using G
 
 | Secret | Description | Required |
 | :--- | :--- | :---: |
-| `GH_TOKEN` | GitHub token or PAT with repository write scope for review comments. | No |
-| `GEMINI` | Gemini API Key used to communicate with Google AI Studio. | Yes |
+| `GITHUB_TOKEN` | GitHub token or PAT with repository write scope for review comments. | No (defaults to caller GITHUB_TOKEN) |
+| `GEMINI_TOKEN` | Gemini API Key used to communicate with Google AI Studio. | **Yes** |
 
 #### Caller Workflow Example
 
+##### Explicit Secrets Mapping (Recommended for custom secret names)
 ```yaml
 name: Code Review
 
@@ -168,6 +169,13 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GH_PAT }}       # Map custom PAT
+      GEMINI_TOKEN: ${{ secrets.GEMINI }}       # Map Gemini Token
+```
+
+##### Seamless Inheritance
+```yaml
     secrets: inherit
 ```
 ```

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -175,7 +175,7 @@ jobs:
 ```
 
 ##### Seamless Inheritance
+
 ```yaml
     secrets: inherit
-```
 ```

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -108,6 +108,12 @@ This repository also publishes reusable workflows under `.github/workflows/`. Th
 
 Integrates the Contributor License Agreement assistant to check and sign CLAs via PR comments.
 
+#### Secrets
+
+| Secret | Description | Required |
+| :--- | :--- | :---: |
+| `GITHUB_TOKEN` | GitHub token or PAT used to update status checks and store signatures in the repository/Gist. | No (defaults to repository context token) |
+
 #### Caller Workflow Example
 
 ```yaml
@@ -122,8 +128,8 @@ on:
 jobs:
   run-cla:
     uses: iamvikshan/.github/.github/workflows/cla.yml@main
+    secrets: inherit
     permissions:
-      actions: write
       contents: write
       pull-requests: write
       statuses: write
@@ -135,6 +141,13 @@ jobs:
 
 Runs PR-Agent reviews, suggestions, and chat interfaces on Pull Requests using Google Gemini. It automatically downloads and merges the centralized configuration from `configs/.pr_agent.toml` of this repository.
 
+#### Secrets
+
+| Secret | Description | Required |
+| :--- | :--- | :---: |
+| `GH_TOKEN` | GitHub token or PAT with repository write scope for review comments. | No |
+| `GEMINI` | Gemini API Key used to communicate with Google AI Studio. | Yes |
+
 #### Caller Workflow Example
 
 ```yaml
@@ -142,13 +155,19 @@ name: Code Review
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
   issue_comment:
     types: [created]
 
 jobs:
   review:
+    # Gating the job ensures Gemini API and secrets aren't exposed on non-PR comments
+    if: ${{ github.event_name == 'pull_request' || github.event.issue.pull_request }}
     uses: iamvikshan/.github/.github/workflows/pr-agent.yml@main
-    # Using secrets: inherit allows passing the necessary secrets (GEMINI and GH_TOKEN) seamlessly
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     secrets: inherit
+```
 ```

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -10,6 +10,10 @@ on:
       path-to-document:
         type: string
         required: false
+    secrets:
+      GITHUB_TOKEN:
+        description: "GitHub token or PAT used by the CLA assistant to write signatures and update PR statuses."
+        required: false
 
 permissions:
   actions: write

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -33,7 +33,7 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-       - name: PR Agent action step
+      - name: PR Agent action step
         uses: The-PR-Agent/pr-agent@v0.36.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -13,8 +13,10 @@ on:
         required: false
     secrets:
       GH_TOKEN:
+        description: "GitHub token (or PAT) for PR-Agent to read PRs and write review comments."
         required: false
       GEMINI:
+        description: "Gemini API key used by PR-Agent to generate AI reviews."
         required: false
 
 concurrency:
@@ -31,7 +33,7 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - name: PR Agent action step
+       - name: PR Agent action step
         uses: The-PR-Agent/pr-agent@v0.36.1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -12,12 +12,12 @@ on:
         default: "https://raw.githubusercontent.com/iamvikshan/.github/main/configs/.pr_agent.toml"
         required: false
     secrets:
-      GH_TOKEN:
+      GITHUB_TOKEN:
         description: "GitHub token (or PAT) for PR-Agent to read PRs and write review comments."
         required: false
-      GEMINI:
+      GEMINI_TOKEN:
         description: "Gemini API key used by PR-Agent to generate AI reviews."
-        required: false
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
@@ -36,6 +36,6 @@ jobs:
        - name: PR Agent action step
         uses: The-PR-Agent/pr-agent@v0.36.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
-          GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOOGLE_AI_STUDIO.GEMINI_API_KEY: ${{ secrets.GEMINI_TOKEN }}
           PR_AGENT_EXTRA_CONFIG_URL: ${{ inputs.extra_config_url }}


### PR DESCRIPTION
This PR declares GITHUB_TOKEN secret input for the CLA assistant reusable workflow and adds descriptions to the GH_TOKEN and GEMINI secrets in PR-Agent. It also updates the reusable actions/workflows documentation in the README.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make secret configuration explicit for the reusable `cla.yml` and `pr-agent.yml` workflows. Renames PR-Agent secrets to `GITHUB_TOKEN`/`GEMINI_TOKEN`, updates env mapping, and refreshes README with secrets tables, safer caller examples, and `secrets: inherit`.

- **Bug Fixes**
  - Fixed YAML step indentation in `pr-agent.yml` to prevent workflow parse failures.
  - Fixed a stray code fence in README that broke formatting.

- **Migration**
  - For `pr-agent.yml`: pass `GEMINI_TOKEN` (required) and optionally `GITHUB_TOKEN`, or use `secrets: inherit` with those names. If you used `GH_TOKEN`/`GEMINI`, map or rename your secrets in the caller workflow.
  - For `cla.yml`: optionally pass `GITHUB_TOKEN` (or rely on the default). Use `secrets: inherit` if you want to forward a PAT.

<sup>Written for commit 3b472aaa024fcd673e91b19e6fa8405df6a059a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/iamvikshan/.github/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Configure secret inputs for CLA and PR Agent reusable workflows
> - Adds a `secrets` block to the [CLA workflow](https://github.com/iamvikshan/.github/pull/38/files#diff-7aa0bb52169dde77e9033b3f574e1c8e686f567ea884691c7aace8f6297d216e) accepting an optional `GITHUB_TOKEN` from callers.
> - Renames secrets in the [PR Agent workflow](https://github.com/iamvikshan/.github/pull/38/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4): `GH_TOKEN` → `GITHUB_TOKEN` (optional) and `GEMINI` → `GEMINI_TOKEN` (required), removing the `GH_TOKEN` fallback.
> - Updates [README.md](https://github.com/iamvikshan/.github/pull/38/files#diff-52d6b7f655d938f43fd7629a638b5183e3fcd1c3d302b3d32479aac06fdacb84) with explicit `Secrets` sections and caller examples for both workflows.
> - Risk: callers passing `GEMINI` or `GH_TOKEN` must update to the new secret names or the PR Agent workflow will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4df4d35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub Actions workflow documentation with clarified secret handling and caller workflow examples.

* **Chores**
  * Enhanced workflow security configurations with explicit secret declarations and refined permissions scoping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes secret inputs explicit for the `cla.yml` and `pr-agent.yml` reusable workflows, renames `GH_TOKEN`/`GEMINI` to `GITHUB_TOKEN`/`GEMINI_TOKEN`, marks `GEMINI_TOKEN` as required, and expands the README with secrets tables and caller examples. However, both workflow files declare `GITHUB_TOKEN` as a `workflow_call` secret — a reserved name that GitHub Actions does not permit callers to explicitly pass — and the README's recommended explicit-mapping example (`GITHUB_TOKEN: ${{ secrets.GH_PAT }}`) will cause callers to produce failing workflows.

- **`pr-agent.yml` and `cla.yml`**: `GITHUB_TOKEN` is declared under `workflow_call.secrets`, but GitHub reserves this name; callers cannot inject a custom value under it, making the declaration misleading and removing the ability to supply a PAT that was previously possible via `GH_TOKEN`.
- **`README.md`**: The "Explicit Secrets Mapping" example maps `GITHUB_TOKEN` to a caller PAT, which GitHub Actions will reject. The `secrets: inherit` alternative shown is valid, but the explicit-mapping path needs a non-reserved secret name (e.g., `PAT_TOKEN`) mapped to `env.GITHUB_TOKEN` inside the workflow.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The `secrets: inherit` path works correctly, but the documented explicit-mapping example will produce broken caller workflows due to the reserved GITHUB_TOKEN constraint.

Both workflow files declare `GITHUB_TOKEN` under `workflow_call.secrets`, and the README instructs callers to map `GITHUB_TOKEN: ${{ secrets.GH_PAT }}` — a pattern GitHub Actions rejects. Any caller who follows the documented "Explicit Secrets Mapping" example will get a failing workflow. The `secrets: inherit` path is unaffected, but the explicit-PAT use-case (which the PR specifically advertises as a migration path for former `GH_TOKEN` users) is broken.

`.github/workflows/pr-agent.yml`, `.github/workflows/cla.yml`, and `.github/actions/README.md` all need updating to replace the `GITHUB_TOKEN` secret slot with a non-reserved name.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/pr-agent.yml | Renames secrets GH_TOKEN→GITHUB_TOKEN and GEMINI→GEMINI_TOKEN, adds descriptions, makes GEMINI_TOKEN required. The GITHUB_TOKEN secret declaration is invalid (reserved name), and the fallback `|| secrets.GITHUB_TOKEN` is removed — callers relying on a PAT via the old GH_TOKEN path now have no supported replacement. |
| .github/workflows/cla.yml | Adds GITHUB_TOKEN as an optional workflow_call secret. Because GITHUB_TOKEN is reserved, this declaration is misleading — callers cannot explicitly pass a PAT under this name; the workflow will always use the auto-generated token. |
| .github/actions/README.md | Adds secrets tables and caller examples for both workflows. The explicit-mapping example for pr-agent uses `GITHUB_TOKEN: ${{ secrets.GH_PAT }}`, which GitHub Actions will reject since GITHUB_TOKEN is a reserved secret name that cannot be explicitly mapped. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as Caller Workflow
    participant GH as GitHub Actions
    participant PRA as pr-agent.yml

    Note over Caller,GH: secrets: inherit (works)
    Caller->>GH: workflow_call with secrets inherit
    GH-->>PRA: GITHUB_TOKEN auto-generated
    GH-->>PRA: GEMINI_TOKEN forwarded

    Note over Caller,GH: Explicit mapping as shown in README (broken)
    Caller->>GH: secrets GITHUB_TOKEN set to custom PAT
    GH--xPRA: GITHUB_TOKEN is reserved, explicit mapping rejected

    Note over Caller,GH: Correct pattern to supply a PAT
    Caller->>GH: secrets PAT_TOKEN set to custom PAT
    GH-->>PRA: PAT_TOKEN forwarded
    PRA-->>PRA: env GITHUB_TOKEN set from PAT_TOKEN
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as Caller Workflow
    participant GH as GitHub Actions
    participant PRA as pr-agent.yml

    Note over Caller,GH: secrets: inherit (works)
    Caller->>GH: workflow_call with secrets inherit
    GH-->>PRA: GITHUB_TOKEN auto-generated
    GH-->>PRA: GEMINI_TOKEN forwarded

    Note over Caller,GH: Explicit mapping as shown in README (broken)
    Caller->>GH: secrets GITHUB_TOKEN set to custom PAT
    GH--xPRA: GITHUB_TOKEN is reserved, explicit mapping rejected

    Note over Caller,GH: Correct pattern to supply a PAT
    Caller->>GH: secrets PAT_TOKEN set to custom PAT
    GH-->>PRA: PAT_TOKEN forwarded
    PRA-->>PRA: env GITHUB_TOKEN set from PAT_TOKEN
```

</a>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
.github/workflows/pr-agent.yml:15-17
**`GITHUB_TOKEN` cannot be declared or passed as a `workflow_call` secret**

GitHub Actions reserves `GITHUB_TOKEN` as a system name; callers cannot explicitly pass it in a `secrets:` mapping, and declaring it under `workflow_call.secrets` is invalid. The README example derived from this declaration (`GITHUB_TOKEN: ${{ secrets.GH_PAT }}`) will therefore fail at the caller side — GitHub will reject or silently override the value, meaning a caller who follows that example and tries to supply a PAT for elevated API access will find the auto-generated token is used instead. To expose a "bring-your-own token" slot, use a different name (e.g., `PAT_TOKEN`) and map it to `env.GITHUB_TOKEN` inside the workflow.

### Issue 2 of 3
.github/workflows/cla.yml:13-16
**`GITHUB_TOKEN` is reserved and cannot be declared in `workflow_call.secrets`**

Same constraint as in `pr-agent.yml`: GitHub reserves the `GITHUB_TOKEN` name for its auto-generated token and does not permit callers to inject a value under that key. Declaring it here gives callers the false impression they can supply a PAT via `secrets: GITHUB_TOKEN: ${{ secrets.MY_PAT }}`, which will fail or be silently ignored. The README's `secrets: inherit` example is safe because inheritance forwards the system token automatically — but the explicit-secrets table header for this entry should note it can only be inherited, not explicitly mapped.

### Issue 3 of 3
.github/actions/README.md:172-174
**Explicit `GITHUB_TOKEN` mapping in caller example will fail**

The line `GITHUB_TOKEN: ${{ secrets.GH_PAT }}` in the "Explicit Secrets Mapping" example asks callers to pass a PAT under the reserved `GITHUB_TOKEN` key. GitHub Actions does not allow this — callers cannot explicitly map a secret named `GITHUB_TOKEN` to a reusable workflow. A caller who follows this example exactly will get a workflow error. To allow a custom PAT to reach the workflow, both the `pr-agent.yml` `workflow_call.secrets` block and this example should use a non-reserved name (e.g., `GH_PAT_TOKEN`), and the env mapping inside the workflow should reference that name.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(readme): fix code fence syntax forma..."](https://github.com/iamvikshan/.github/commit/4df4d3541d4caeaeb41edccab4be4ea6480b56b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39120847)</sub>

<!-- /greptile_comment -->