### PR TITLE
fix(action): allow composite actions under actions directory in path validation

### DIFF
--- a/.github/actions/bun/action.yml
+++ b/.github/actions/bun/action.yml
@@ -57,6 +57,7 @@ runs:
         }
 
         workspace_root="$(realpath_m "$GITHUB_WORKSPACE")"
+        actions_root="$(realpath_m "$workspace_root/../../_actions")"
         install_paths=()
         install_args=()
 
@@ -94,7 +95,7 @@ runs:
           fi
 
           case "$resolved_path" in
-            "$workspace_root"|"$workspace_root"/*) ;;
+            "$workspace_root"|"$workspace_root"/*|"$actions_root"|"$actions_root"/*) ;;
             *)
               echo "Install path escapes workspace: $install_path" >&2
               exit 1


### PR DESCRIPTION
This PR fixes a bug in `.github/actions/bun` where composite actions utilizing it fail path validation. 

### Issue
When a composite action runs, its action path is located under the runner's `_actions` directory (e.g. `/home/runner/work/_actions/`), which lies outside the caller repository's `$GITHUB_WORKSPACE`. When the `working-directory` fallback resolves to this directory, it is blocked by the workspace escape check, throwing `Install path escapes workspace`.

### Solution
This PR resolves the issue cleanly and securely by:
- Dynamically resolving the runner's actions root relative to the workspace root: `actions_root="$(realpath -m "$workspace_root/../../_actions")"`.
- Whitelisting paths that fall under either the workspace root or the actions root directory.
- Keeping the path validation check DRY and consistent for all paths (no special state flags or branches).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix path validation in `.github/actions/bun` so composite actions running from the runner `_actions` directory are allowed. We resolve `actions_root` relative to the workspace and whitelist it alongside `workspace_root` to prevent false "Install path escapes workspace" errors.

<sup>Written for commit 060abdc95185ef9fbb4fd44762c82ed446975c49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/iamvikshan/.github/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow composite actions under `_actions` directory in path validation
> The `bun` composite action's install-path validation previously rejected paths outside the workspace, blocking use from other composite actions stored in the repository's `_actions` directory. The fix resolves the absolute path to `_actions` and accepts it as a second valid root alongside the workspace.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 060abdc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the path-escape guard in the `bun` composite action to also allow install paths that fall under the runner's `_actions` directory, fixing a breakage where composite-action callers resolve their working directory to a path under `_actions` and are erroneously blocked.

- Adds `actions_root` computed as `realpath_m \"$workspace_root/../../_actions\"` immediately after `workspace_root` is set.
- Extends the `case` guard from matching only `$workspace_root` and its children to also matching `$actions_root` and its children, keeping the check DRY with no extra branches.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for GitHub-hosted runners; self-hosted runners with non-standard workspace layouts could compute the wrong `actions_root`.

The fix is minimal, targeted, and keeps the path-validation logic DRY. The one concern is that `../../_actions` is a hardcoded structural assumption about how the runner arranges directories relative to `$GITHUB_WORKSPACE`. On GitHub-hosted runners this is always correct. On self-hosted runners the workspace path is configurable and the two-level offset may not hold, which could cause the computed `actions_root` to point to an unrelated directory.

`.github/actions/bun/action.yml` — specifically the `actions_root` derivation on line 60.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/actions/bun/action.yml | Adds `actions_root` computed as `workspace_root/../../_actions` and extends the path-escape guard to allow installs under that directory, enabling composite-action callers whose working directory resolves inside `_actions`. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Start: for each install_path"] --> B{Absolute path?}
    B -- Yes --> C["resolved_path = realpath_m(install_path)"]
    B -- No --> D["resolved_path = realpath_m(workspace_root / install_path)"]
    C --> E{Path check}
    D --> E
    E -- "under workspace_root?" --> G["✓ Run bun install"]
    E -- "under actions_root? (NEW)" --> G
    E -- "neither" --> F["✗ error: escapes workspace, exit 1"]
    G --> H[Next path]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Start: for each install_path"] --> B{Absolute path?}
    B -- Yes --> C["resolved_path = realpath_m(install_path)"]
    B -- No --> D["resolved_path = realpath_m(workspace_root / install_path)"]
    C --> E{Path check}
    D --> E
    E -- "under workspace_root?" --> G["✓ Run bun install"]
    E -- "under actions_root? (NEW)" --> G
    E -- "neither" --> F["✗ error: escapes workspace, exit 1"]
    G --> H[Next path]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/actions/bun/action.yml`, line 60 ([link](https://github.com/iamvikshan/.github/blob/060abdc95185ef9fbb4fd44762c82ed446975c49/.github/actions/bun/action.yml#L60)) 

   **Hardcoded `../../` offset may break on self-hosted runners**

   The `../../_actions` navigation assumes `$GITHUB_WORKSPACE` is always exactly two levels deep under the directory that sibling-contains `_actions` (e.g. `/home/runner/work/REPO/REPO` → `/home/runner/work/_actions`). On GitHub-hosted runners this is always true, but self-hosted runners allow arbitrary workspace paths via `--work` or the `RUNNER_WORKDIR` setting. If the workspace is one level deeper or shallower, `actions_root` resolves to the wrong directory — either silently allowing paths that shouldn't be allowed, or blocking legitimate action paths. Consider reading `$RUNNER_WORKSPACE` (one level above `$GITHUB_WORKSPACE`, always set by the runner) and appending `../_actions` instead: `actions_root="$(realpath_m "$(realpath_m "$RUNNER_WORKSPACE")/../_actions")"`.

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/actions/bun/action.yml:60
**Hardcoded `../../` offset may break on self-hosted runners**

The `../../_actions` navigation assumes `$GITHUB_WORKSPACE` is always exactly two levels deep under the directory that sibling-contains `_actions` (e.g. `/home/runner/work/REPO/REPO` → `/home/runner/work/_actions`). On GitHub-hosted runners this is always true, but self-hosted runners allow arbitrary workspace paths via `--work` or the `RUNNER_WORKDIR` setting. If the workspace is one level deeper or shallower, `actions_root` resolves to the wrong directory — either silently allowing paths that shouldn't be allowed, or blocking legitimate action paths. Consider reading `$RUNNER_WORKSPACE` (one level above `$GITHUB_WORKSPACE`, always set by the runner) and appending `../_actions` instead: `actions_root="$(realpath_m "$(realpath_m "$RUNNER_WORKSPACE")/../_actions")"`.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(action): allow composite actions und..."](https://github.com/iamvikshan/.github/commit/060abdc95185ef9fbb4fd44762c82ed446975c49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39554469)</sub>

<!-- /greptile_comment -->