### PR TITLE
fix: explicitly set gpg.ssh.program to ssh-keygen

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -195,12 +195,14 @@ fi
 # Set global configuration with --replace-all for absolute certainty
 git config --global --replace-all gpg.format ssh
 git config --global --replace-all user.signingkey "${KEY_PATH}.pub"
+git config --global --replace-all gpg.ssh.program ssh-keygen
 git config --global --replace-all commit.gpgsign true
 
 # Enforce strictly at the local level to override any phantom environment variables
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   git config --local --replace-all gpg.format ssh
   git config --local --replace-all user.signingkey "${KEY_PATH}.pub"
+  git config --local --replace-all gpg.ssh.program ssh-keygen
   git config --local --replace-all commit.gpgsign true
 fi
 


### PR DESCRIPTION
This PR updates the bootstrap script to explicitly configure `gpg.ssh.program` to `ssh-keygen` at both the global and local levels. This overrides any default/system-level configuration (such as DevPod's `devpod-ssh-signature` daemon tunnel) which might fail due to connectivity or status issues, ensuring robust SSH commit signing across all workspace containers using the standard SSH signature utility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force Git SSH signing to use `ssh-keygen` by explicitly setting `gpg.ssh.program` at global and local scopes in the bootstrap script. This avoids flaky defaults (e.g., DevPod's `devpod-ssh-signature` tunnel) and ensures reliable signed commits across workspace containers.

<sup>Written for commit 8ffc0090781262fc15ab239915e8bdfef0e6cfd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/iamvikshan/.github/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved repository setup to automatically configure Git for SSH-based commit signing.
  * Ensures signing settings are applied consistently in both global and local Git configurations for smoother setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->