### PR TITLE
chore: separate some environment specific rules.

### DIFF
--- a/renovate/base.json
+++ b/renovate/base.json
@@ -2,6 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Base Renovate configuration for all iamvikshan repositories.",
   "extends": ["config:recommended"],
+  "automerge": true,
+  "minimumReleaseAge": "0 days",
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
   "pinDigests": false,
@@ -17,57 +19,28 @@
   "separateMinorPatch": true,
   "separateMajorMinor": true,
   "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true
+    "enabled": true
   },
+  
   "packageRules": [
     {
-      "description": "Default minimum release age for non-production dependencies is 0 days",
-      "matchPackagePatterns": ["*"],
-      "minimumReleaseAge": "0 days"
-    },
-    {
-      "description": "Production dependencies (dependencies) get a 3-day minimum release age",
+      "description": "Production dependencies get a 3-day minimum release age",
       "matchDepTypes": ["dependencies"],
       "minimumReleaseAge": "3 days"
     },
     {
-      "description": "Automerge minor and patch updates for all dependency types",
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
-    },
-    {
-      "description": "Automerge all updates for devDependencies at any time",
-      "matchDepTypes": ["devDependencies"],
-      "automerge": true
-    },
-    {
-      "description": "Automerge all updates for GitHub Actions at any time",
-      "matchManagers": ["github-actions"],
-      "automerge": true
-    },
-    {
-      "description": "Disable automerge for major updates of production dependencies",
+      "description": "Disable automerge for major updates of production dependencies, use fix commit, and group them",
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["major"],
-      "automerge": false
+      "automerge": false,
+      "semanticCommitType": "fix",
+      "groupName": "production-dependencies-major"
     },
     {
-      "description": "Use fix: commit type for major updates of production dependencies",
-      "matchDepTypes": ["dependencies"],
-      "matchUpdateTypes": ["major"],
-      "semanticCommitType": "fix"
-    },
-    {
-      "description": "Ensure commit type is chore: for minor/patch updates of production dependencies",
+      "description": "Group production dependencies minor/patch updates",
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["minor", "patch"],
-      "semanticCommitType": "chore"
-    },
-    {
-      "description": "Do not pin digests for GitHub Actions",
-      "matchManagers": ["github-actions"],
-      "pinDigests": false
+      "groupName": "production-dependencies-minor-patch"
     },
     {
       "description": "Group development dependencies",
@@ -78,32 +51,10 @@
       "description": "Group GitHub Actions updates",
       "matchManagers": ["github-actions"],
       "groupName": "github-actions"
-    },
-    {
-      "description": "Group production dependencies minor/patch updates",
-      "matchDepTypes": ["dependencies"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "production-dependencies-minor-patch"
-    },
-    {
-      "description": "Group production dependencies major updates",
-      "matchDepTypes": ["dependencies"],
-      "matchUpdateTypes": ["major"],
-      "groupName": "production-dependencies-major"
-    },
-    {
-      "description": "Group Docker updates",
-      "matchManagers": ["dockerfile", "docker-compose"],
-      "groupName": "docker-dependencies"
-    },
-    {
-      "description": "Group Pub (Dart/Flutter) updates",
-      "matchManagers": ["pub"],
-      "groupName": "pub-dependencies"
     }
   ],
+  
   "vulnerabilityAlerts": {
-    "labels": ["security"],
-    "automerge": true
+    "labels": ["security"]
   }
 }

--- a/renovate/docker.json
+++ b/renovate/docker.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["github>iamvikshan/.github//renovate/base"],
+  "packageRules": [
+    {
+      "description": "Group Docker updates",
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "groupName": "docker-dependencies"
+    }
+  ]
+}

--- a/renovate/flutter.json
+++ b/renovate/flutter.json
@@ -1,0 +1,10 @@
+{
+  "extends": ["github>iamvikshan/.github//renovate/base"],
+  "packageRules": [
+    {
+      "description": "Group Pub (Dart/Flutter) updates",
+      "matchManagers": ["pub"],
+      "groupName": "pub-dependencies"
+    }
+  ]
+}

--- a/renovate/typescript.json
+++ b/renovate/typescript.json
@@ -14,8 +14,7 @@
     },
     {
       "groupName": "TypeScript and types",
-      "matchPackageNames": ["typescript", "/^@types/"],
-      "automerge": true
+      "matchPackageNames": ["typescript", "/^@types/"]
     }
   ]
 }


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Split Renovate rules by environment (Docker, Flutter) and simplified the base preset to make updates clearer and safer for production dependencies.

- **Refactors**
  - Added `renovate/docker.json` and `renovate/flutter.json` for Docker and Pub grouping; both extend `github>iamvikshan/.github//renovate/base`.
  - Simplified `renovate/base.json`: global `automerge`, default 0‑day release age; keep 3‑day age for `dependencies`; group production deps (minor/patch and major); block automerge for production majors and mark them as `fix`; removed redundant rules; vulnerability alerts no longer auto‑merge.
  - Updated `renovate/typescript.json` to keep the TypeScript/@types group without automerge.

<sup>Written for commit ac45ee1b3283c836b8c737e5a7671458c964cfe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/iamvikshan/.github/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR splits some Renovate rules into environment-specific presets. The main changes are:

- Adds shared base defaults for automerge and minimum release age.
- Moves Docker grouping into a new `renovate/docker.json` preset.
- Moves Flutter/Pub grouping into a new `renovate/flutter.json` preset.
- Removes the TypeScript-specific automerge override because it now inherits from the base preset.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

One contained configuration issue needs to be fixed before merging.

The preset split is small, but the base `automerge` change alters inherited behavior for environment-specific major updates.

`renovate/base.json`
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reproduced the global automerge behavior by running a Node harness against the actual Renovate presets with Renovate CLI 43.256.2, and observed that the Docker major update and Pub major update cases inherited automerge=true but did not match the production dependencies major opt-out rule due to matchDepTypes not matching.
- I produced a proof for a posted P2 finding and linked it to the corresponding review comment for details.
- I inspected the after-run artifacts and confirmed that all changed Renovate preset JSON files parsed and passed narrow structural checks, while a separate format check reported issues and the validator was blocked by authentication requirements.

<a href="https://app.greptile.com/trex/runs/13862753/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| renovate/base.json | Moves common Renovate automerge and minimum-release-age settings into the base preset, but broadens inherited automerge behavior. |
| renovate/docker.json | Adds a Docker-specific preset extending the base config and grouping Docker manager updates. |
| renovate/flutter.json | Adds a Flutter/Pub-specific preset extending the base config and grouping Pub updates. |
| renovate/typescript.json | Removes a redundant TypeScript/types automerge override now inherited from the base preset. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Changed Renovate base preset fails repository formatter check**

   - **Bug**
     - The requested formatter validation failed with `npm run f:check`, and the output explicitly includes the changed file `renovate/base.json`. A targeted context capture shows whitespace-only blank lines at lines 24 and 56, which are consistent with formatter rejection. Other unrelated files were also listed, but this changed file is independently included in the formatter failure.
   - **Cause**
     - `renovate/base.json` contains formatting that does not match the repository's `oxfmt --check` expectations, including trailing spaces on otherwise blank lines.
   - **Fix**
     - Run the repository formatter on `renovate/base.json` or remove the trailing whitespace from blank lines in the changed file, then rerun `npm run f:check`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
renovate/base.json:5
**Global automerge broadens scope**
Setting `automerge` at the shared base level enables automerge for every update inherited by `renovate/docker.json` and `renovate/flutter.json`, including Docker and Pub major updates. The previous base only enabled automerge through package rules for minor/patch updates and dev/action updates, and the only new opt-out here is `dependencies` majors, so environment-specific major updates now merge automatically.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: separate some environment specifi..."](https://github.com/iamvikshan/.github/commit/ac45ee1b3283c836b8c737e5a7671458c964cfe2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43061225)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->