### PR TITLE
fix: identity-guard — run everywhere, check effective config, fix error message

### DIFF
--- a/scripts/husky/identity-guard.sh
+++ b/scripts/husky/identity-guard.sh
@@ -7,39 +7,57 @@ if [ "${CI:-}" = "true" ] || [ -n "${GITHUB_ACTIONS:-}" ] || [ -n "${GITLAB_CI:-
   exit 0
 fi
 
-# Codespaces (or general dev environment) identity check
-if [ -n "${CODESPACES:-}" ]; then
-  # Read from the local cache set by bootstrap.sh
-  EXPECTED_NAME=$(git config --local atlas.expected-name 2>/dev/null || echo "")
-  EXPECTED_EMAIL=$(git config --local atlas.expected-email 2>/dev/null || echo "")
+# Read the expected identity from local git config (set by bootstrap)
+EXPECTED_NAME=$(git config --local atlas.expected-name 2>/dev/null || echo "")
+EXPECTED_EMAIL=$(git config --local atlas.expected-email 2>/dev/null || echo "")
 
-  if [ -z "$EXPECTED_NAME" ] || [ -z "$EXPECTED_EMAIL" ]; then
-    echo "❌ Error: Local expected identity not found."
-    echo "   Please run your environment setup:"
-    echo "   bash scripts/bootstrap.sh"
-    exit 1
+if [ -z "$EXPECTED_NAME" ] || [ -z "$EXPECTED_EMAIL" ]; then
+  echo "❌ Error: Expected identity not configured."
+  echo "   Run 'bun bs' to bootstrap your environment, or set manually:"
+  echo "     git config --local atlas.expected-name \"Your Name\""
+  echo "     git config --local atlas.expected-email \"you@example.com\""
+  exit 1
+fi
+
+# Resolve effective author identity (local config > global config > env vars)
+# git config without --global returns local first, then global
+CONFIG_USER=$(git config user.name 2>/dev/null || echo "")
+CONFIG_EMAIL=$(git config user.email 2>/dev/null || echo "")
+EFFECTIVE_USER="${GIT_AUTHOR_NAME:-$CONFIG_USER}"
+EFFECTIVE_EMAIL="${GIT_AUTHOR_EMAIL:-$CONFIG_EMAIL}"
+
+# Resolve effective committer identity
+EFFECTIVE_COMMITTER_USER="${GIT_COMMITTER_NAME:-$EFFECTIVE_USER}"
+EFFECTIVE_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL:-$EFFECTIVE_EMAIL}"
+
+if [ "$EFFECTIVE_USER" != "$EXPECTED_NAME" ] || [ "$EFFECTIVE_EMAIL" != "$EXPECTED_EMAIL" ]; then
+  echo "❌ Git identity mismatch!"
+  echo "   Expected:  $EXPECTED_NAME <$EXPECTED_EMAIL>"
+  echo "   Effective: $EFFECTIVE_USER <$EFFECTIVE_EMAIL>"
+  if [ -n "${GIT_AUTHOR_NAME:-}" ] || [ -n "${GIT_AUTHOR_EMAIL:-}" ]; then
+    echo "   (GIT_AUTHOR_NAME/EMAIL env vars are overriding git config)"
   fi
+  echo ""
+  echo "To fix, run 'bun bs' or set your identity:"
+  echo "   git config user.name \"$EXPECTED_NAME\""
+  echo "   git config user.email \"$EXPECTED_EMAIL\""
+  echo ""
+  exit 1
+fi
 
-  CURRENT_USER=$(git config --global user.name 2>/dev/null || echo "")
-  CURRENT_EMAIL=$(git config --global user.email 2>/dev/null || echo "")
-
-  # Also check GIT_AUTHOR_* env vars which override git config at commit time
-  EFFECTIVE_USER="${GIT_AUTHOR_NAME:-$CURRENT_USER}"
-  EFFECTIVE_EMAIL="${GIT_AUTHOR_EMAIL:-$CURRENT_EMAIL}"
-
-  if [ "$EFFECTIVE_USER" != "$EXPECTED_NAME" ] || [ "$EFFECTIVE_EMAIL" != "$EXPECTED_EMAIL" ]; then
-    echo "❌ Git identity mismatch detected in Codespaces!"
-    echo "   Expected:  $EXPECTED_NAME <$EXPECTED_EMAIL>"
-    echo "   Effective: $EFFECTIVE_USER <$EFFECTIVE_EMAIL>"
-    if [ -n "${GIT_AUTHOR_NAME:-}" ] || [ -n "${GIT_AUTHOR_EMAIL:-}" ]; then
-      echo "   (GIT_AUTHOR_NAME/EMAIL env vars are overriding git config)"
-    fi
-    echo ""
-    echo "To fix this attribution, please run:"
-    echo "   bash scripts/bootstrap.sh"
-    echo ""
-    exit 1
+if [ "$EFFECTIVE_COMMITTER_USER" != "$EXPECTED_NAME" ] || [ "$EFFECTIVE_COMMITTER_EMAIL" != "$EXPECTED_EMAIL" ]; then
+  echo "❌ Git committer identity mismatch!"
+  echo "   Expected:  $EXPECTED_NAME <$EXPECTED_EMAIL>"
+  echo "   Committer: $EFFECTIVE_COMMITTER_USER <$EFFECTIVE_COMMITTER_EMAIL>"
+  if [ -n "${GIT_COMMITTER_NAME:-}" ] || [ -n "${GIT_COMMITTER_EMAIL:-}" ]; then
+    echo "   (GIT_COMMITTER_NAME/EMAIL env vars are overriding git config)"
   fi
+  echo ""
+  echo "To fix, run 'bun bs' or set your identity:"
+  echo "   git config user.name \"$EXPECTED_NAME\""
+  echo "   git config user.email \"$EXPECTED_EMAIL\""
+  echo ""
+  exit 1
 fi
 
 exit 0

--- a/scripts/husky/identity-guard.sh
+++ b/scripts/husky/identity-guard.sh
@@ -35,7 +35,8 @@ if [ "$EFFECTIVE_USER" != "$EXPECTED_NAME" ] || [ "$EFFECTIVE_EMAIL" != "$EXPECT
   echo "   Expected:  $EXPECTED_NAME <$EXPECTED_EMAIL>"
   echo "   Effective: $EFFECTIVE_USER <$EFFECTIVE_EMAIL>"
   if [ -n "${GIT_AUTHOR_NAME:-}" ] || [ -n "${GIT_AUTHOR_EMAIL:-}" ]; then
-    echo "   (GIT_AUTHOR_NAME/EMAIL env vars are overriding git config)"
+    echo "   (GIT_AUTHOR_NAME/EMAIL env vars are overriding git config — unset them first)"
+    echo "     unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL"
   fi
   echo ""
   echo "To fix, run 'bun bs' or set your identity:"

--- a/scripts/husky/identity-guard.sh
+++ b/scripts/husky/identity-guard.sh
@@ -19,7 +19,7 @@ if [ -z "$EXPECTED_NAME" ] || [ -z "$EXPECTED_EMAIL" ]; then
   exit 1
 fi
 
-# Resolve effective author identity (local config > global config > env vars)
+# Resolve effective author identity (env vars > local config > global config)
 # git config without --global returns local first, then global
 CONFIG_USER=$(git config user.name 2>/dev/null || echo "")
 CONFIG_EMAIL=$(git config user.email 2>/dev/null || echo "")


### PR DESCRIPTION
## Changes

- **Remove Codespaces-only gate**: identity check now runs in all environments, not just Codespaces
- **Check effective config**: `git config user.name` (without `--global`) picks up local config first, then global. Previously only checked `--global`, so a repo-local identity could bypass the guard.
- **Add GIT_COMMITTER_\*** checks: also validate committer identity alongside author identity
- **Fix error message**: reference `bun bs` instead of nonexistent `scripts/bootstrap.sh`, with manual `git config --local` fallback

## Why

The identity guard was effectively disabled in most environments and could be bypassed even when enabled.

Closes issues from code review on amina.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the git identity guard run in all environments and validate the effective author and committer using env var overrides and local/global git config. Update errors to reference `bun bs`, show how to unset overrides, and include direct `git config` commands.

- **Bug Fixes**
  - Run the identity guard everywhere (not just Codespaces).
  - Require expected identity from local `atlas.expected-*`; error if missing with manual `git config --local` setup.
  - Resolve effective author via `git config user.name/email` (local first, then global) with `GIT_AUTHOR_*` overrides; show when env vars override and how to `unset` them.
  - Validate committer with `GIT_COMMITTER_*`; mismatch guidance uses `bun bs` or set `user.name`/`user.email`.

<sup>Written for commit 36ab247a17db153f6ecdae8ac5b2844c187f11f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/iamvikshan/.github/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Husky identity guard for local commits. The main changes are:

- Runs the guard in all non-CI environments instead of only Codespaces.
- Reads expected identity from local `atlas.expected-*` config.
- Checks effective author identity using `GIT_AUTHOR_*` before Git config.
- Adds committer identity validation using `GIT_COMMITTER_*`.
- Updates setup guidance to use `bun bs` and manual `git config` commands.

<h3>Confidence Score: 4/5</h3>

One contained issue remains in the committer validation path.

The guard mostly follows the intended identity checks, but the new committer check does not match Git’s fallback behavior when only `GIT_AUTHOR_*` is set.

**Files Needing Attention:** `scripts/husky/identity-guard.sh`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the committer config fallback verification by running a narrow isolated git-repo harness; the identity guard exited 0 with no mismatch output, while a real commit showed the author as the expected identity and the committer as the mismatched local config.
- Saved and reviewed reproducibility artifacts, including the identity-guard-matrix.sh harness and the per-case execution log, which shows the command flow, working directory, exit codes, and per-case results.
- Captured key evidence of updated identity guidance and mismatch outputs, such as the updated bun bs/manual config guidance, and the CI skip message for HUSKY=0.

<a href="https://app.greptile.com/trex/runs/16895723/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/husky/identity-guard.sh | Expands the identity guard to all non-CI environments and validates expected author and committer identities, but the committer fallback incorrectly reuses author env overrides. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
participant Dev as Developer commit
participant Guard as identity-guard.sh
participant Git as git config/env
Guard->>Git: Read atlas.expected-name/email (--local)
Git-->>Guard: Expected identity
Guard->>Git: Read user.name/user.email (effective config)
Git-->>Guard: Config identity
Guard->>Guard: "Apply GIT_AUTHOR_* overrides for author"
Guard->>Guard: "Apply GIT_COMMITTER_* overrides for committer"
alt author or committer mismatch
    Guard-->>Dev: Print remediation and exit 1
else identities match
    Guard-->>Dev: exit 0
end
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/husky/identity-guard.sh:29-31
**Use committer config fallback**
`GIT_AUTHOR_*` does not determine Git’s committer identity when `GIT_COMMITTER_*` is unset; Git falls back to `user.name` and `user.email`. With expected `GIT_AUTHOR_*` and mismatched config, this guard passes the committer check while Git still creates the commit with the wrong committer.

```suggestion
# Resolve effective committer identity
EFFECTIVE_COMMITTER_USER="${GIT_COMMITTER_NAME:-$CONFIG_USER}"
EFFECTIVE_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL:-$CONFIG_EMAIL}"
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update scripts/husky/identity-guard.sh"](https://github.com/iamvikshan/.github/commit/36ab247a17db153f6ecdae8ac5b2844c187f11f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49335239)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->